### PR TITLE
Cleanup @ng-select/ng-select dependency

### DIFF
--- a/projects/worldskills-angular-lib/package.json
+++ b/projects/worldskills-angular-lib/package.json
@@ -4,11 +4,10 @@
   "peerDependencies": {
     "@angular/common": "^10.0.4",
     "@angular/core": "^10.0.4",
-    "angular-oauth2-oidc": "^10.0.3",
-    "ng-select": "^1.0.2",
-    "@ng-select/ng-select": "^4.0.4",
     "@ng-bootstrap/ng-bootstrap": "^7.0.0",
+    "@ng-select/ng-select": ">=4.0.4 <6.0.0",
     "@worldskills/bootstrap": "^4.4.1",
+    "angular-oauth2-oidc": "^10.0.3",
     "bootstrap": "^4.5.0",
     "font-awesome": "^4.7.0"
   },


### PR DESCRIPTION
@TehWazzard I was trying to update the lib in worldskills-quizzes and found some dependency issues:

1. The lib depends on angular v10 and @ng-select/ng-select v4 - but @ng-select/ng-select actually requires v5 for angular v10: https://github.com/ng-select/ng-select#versions
2. We have two "ng-select" peer dependencies declared [ng-select](https://github.com/basvandenberg/ng-select) and [@ng-select/ng-select](https://github.com/ng-select/ng-select). I think the second one is the correct one and the first one can be removed as their last release was 2 years ago.

This pull request should fix those two issues.