### PR TITLE
Set fallback lang code to 'en' in WsHttpInterceptor

### DIFF
--- a/projects/worldskills-angular-lib/src/lib/interceptors/ws-http.interceptor.ts
+++ b/projects/worldskills-angular-lib/src/lib/interceptors/ws-http.interceptor.ts
@@ -33,10 +33,10 @@ export class WsHttpInterceptor implements HttpInterceptor {
         });
       }
 
-      // appent language code
+      // append language code
       if (includeLanguageParam) {
-        // appendd language param to requests
-        const lang = sessionStorage.getItem('lang');
+        // append language param to requests
+        const lang = sessionStorage.getItem('lang') ?? 'en';
         req = req.clone({
           params: (req.params ? req.params : new HttpParams())
             .set('l', lang),


### PR DESCRIPTION
Hi @TehWazzard ,

I had an issue in Award certificate public verification page. If you try to click this link below, the HttpRequest failed (Spinner keeps spinning forever). Then if you refresh it the second time, it succeed.
https://awards.worldskills.show/certificate/c7c5665f-18d7-4adf-a406-7682beb73572/verify

After some investigation, I found that the Interceptor is setting a null value to `Accept-Language` header in the initial page load when no lang code is set in sessionStorage yet. So this PR fixes it by falling back to 'en'